### PR TITLE
fix: public URLs are localhost in the editor (not kapeta.dev)

### DIFF
--- a/src/renderer/components/plan-editor/panels/GatewaysList.tsx
+++ b/src/renderer/components/plan-editor/panels/GatewaysList.tsx
@@ -104,6 +104,7 @@ export const PlannerGatewaysList = withErrorBoundary(
                                     key={blockId}
                                     status={status}
                                     title={instance.name || definition.metadata.title || definition.metadata.name}
+                                    fallbackText="Open on localhost"
                                     fallback={{
                                         url: url || null,
                                     }}


### PR DESCRIPTION
The local URLs are right, but the Public URLs should use the same text:
![Screenshot 2023-11-01 at 08 58 35](https://github.com/kapetacom/app-desktop-builder/assets/296057/178eb9b3-6a4f-410e-a589-f91ca87e3de5)

![Screenshot 2023-11-01 at 08 58 30](https://github.com/kapetacom/app-desktop-builder/assets/296057/282c031e-e417-4305-aa36-93c566350e11)
