### PR TITLE
fix: reload blocks and resources on change [KAP-1902]

### DIFF
--- a/src/renderer/components/plan-editor/PlanEditor.tsx
+++ b/src/renderer/components/plan-editor/PlanEditor.tsx
@@ -38,6 +38,7 @@ import { Box, Badge, Tab, Tabs, styled } from '@mui/material';
 import { PlannerGatewaysList } from './panels/GatewaysList';
 import { getStatusDotForGroup } from '../../utils/statusDot';
 import { DesktopReferenceResolutionHandler } from '../general/DesktopReferenceResolutionHandler';
+import { useEffect } from 'react';
 
 interface Props {
     systemId: string;
@@ -62,11 +63,18 @@ export const StyledTab = styled(Tab, {
     },
 });
 
+const useAssetInvalidationKey = (blocks: any[], resources: any[]) => {
+    const [assetKey, setAssetKey] = useState(0);
+    useEffect(() => setAssetKey((key) => key + 1), [blocks, resources]);
+    return assetKey;
+};
+
 export const PlanEditor = withPlannerContext(
     forwardRef((props: Props, ref: ForwardedRef<HTMLDivElement>) => {
         const uri = parseKapetaUri(props.systemId);
         const planner = useContext(PlannerContext);
         const kapetaContext = useKapetaContext();
+        const assetInvalidationKey = useAssetInvalidationKey(planner.blockAssets, props.resourceAssets);
 
         const [configInfo, setConfigInfo] = useState<ConfigureItemInfo | null>(null);
         const [inspectInfo, setInspectInfo] = useState<InspectItemInfo | null>(null);
@@ -249,6 +257,8 @@ export const PlanEditor = withPlannerContext(
                     </Tabs>
                     {currentTab === 'assets' && (
                         <PlannerResourcesList
+                            // Invalidate the resource list on local assets change
+                            key={assetInvalidationKey}
                             onShowMoreAssets={() => {
                                 kapetaContext.blockHub.open(planner.asset!, (selection) => {
                                     selection.forEach((asset, i) => {

--- a/src/renderer/components/shell/components/BlockhubShell.tsx
+++ b/src/renderer/components/shell/components/BlockhubShell.tsx
@@ -83,7 +83,7 @@ export const BlockhubShell = (props: Props) => {
     useAssetsChanged(() => {
         // We only get notified of local changes
         localAssets.retry();
-    }, []);
+    }, [localAssets.retry]);
 
     useEffect(() => {
         if (kapetaContext.blockHub.visible) {


### PR DESCRIPTION
Invalidate the planner resource list when blocks or resources have changed.
This ensures that the assets that can be dragged into the plan are up to date.
