### PR TITLE
fix: KAP-1888 upgrading ui-web-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3513,9 +3513,9 @@
             "integrity": "sha512-mafdrXCc2mtq5oY2sIj+bAJf1epGrh2mz3mwFf2u+Gii/2Mh/urjtpgXv99simQHVk6xNPb/s49GvvxTvE3erQ=="
         },
         "node_modules/@kapeta/ui-web-components": {
-            "version": "0.53.1",
-            "resolved": "https://registry.npmjs.org/@kapeta/ui-web-components/-/ui-web-components-0.53.1.tgz",
-            "integrity": "sha512-0sLHy+oZvNqW0h94HSXK5+orppJvJj7bfV4K1C+1TD20kXMcmN8Z5ihJemOS0YZ/F36lT92w3vYSO+PkLR8UcA==",
+            "version": "0.53.2",
+            "resolved": "https://registry.npmjs.org/@kapeta/ui-web-components/-/ui-web-components-0.53.2.tgz",
+            "integrity": "sha512-gL6+SK9aU/AGar2AAprDJTlyw5KT8/zfUIbDH2Gfxf5c4v5aW90WSFDUa87qExwhVeNayaXqtm3Hi3/PP6lLSw==",
             "dependencies": {
                 "@kapeta/nodejs-utils": "^0.0.10",
                 "@kapeta/style": "^0.94.0",


### PR DESCRIPTION
This includes the ability to save kapeta.yml files with an argument to the
REST Header type like @Header("X-Kapeta-Tags")
This fixes KAP-1888