### PR TITLE
Left menu style fix + some other small styling fixes

### DIFF
--- a/src/renderer/components/general/CodeBlock.tsx
+++ b/src/renderer/components/general/CodeBlock.tsx
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { Box, IconButton, Typography } from '@mui/material';
+import { Box, IconButton } from '@mui/material';
 import grey from '@mui/material/colors/grey';
 import React from 'react';
 import CopyAllIcon from '@mui/icons-material/CopyAll';
 import CheckIcon from '@mui/icons-material/Check';
-import { showError } from '../../../main/helpers';
 import { showToasty, ToastType } from '@kapeta/ui-web-components';
 
 interface Props {
@@ -24,7 +23,7 @@ export const CodeBlock = (props: Props) => {
             sx={{
                 backgroundColor: grey[800],
                 color: grey[100],
-                p: 1,
+                p: 0,
                 borderRadius: 1,
                 position: 'relative',
                 '.MuiIconButton-root': {
@@ -40,7 +39,7 @@ export const CodeBlock = (props: Props) => {
             <Box
                 component="pre"
                 sx={{
-                    p: 0,
+                    p: 1,
                     m: 0,
                     fontSize: '0.8rem',
                     fontFamily: 'monospace',

--- a/src/renderer/components/plan-editor/PlanEditorTopMenu.tsx
+++ b/src/renderer/components/plan-editor/PlanEditorTopMenu.tsx
@@ -593,27 +593,23 @@ export const PlanEditorTopMenu = (props: Props) => {
                 }}
                 onClose={() => setPublishButton(null)}
             >
-                <Box
+                <Stack
                     sx={{
-                        width: 400,
+                        maxWidth: 500,
                         pt: 2,
                         px: 4,
                         pb: 3,
                     }}
+                    gap={1}
                 >
                     <Typography variant="h5">Publish to Kapeta</Typography>
+
                     <Typography variant="body2">
                         Publish your plan to Kapeta to be able to run this plan in a cloud environment and/or share it
                         with others.
                     </Typography>
 
-                    <Typography
-                        variant="body2"
-                        sx={{
-                            mt: 1,
-                            fontWeight: 600,
-                        }}
-                    >
+                    <Typography variant="body2" fontWeight={600}>
                         Note: You can also publish via CI/CD -{' '}
                         <a href="https://docs.kapeta.com/docs/working-with-cicd" target={'_blank'}>
                             see the docs
@@ -621,20 +617,13 @@ export const PlanEditorTopMenu = (props: Props) => {
                         for more info.
                     </Typography>
 
-                    <Typography
-                        variant="body2"
-                        sx={{
-                            mt: 1,
-                        }}
-                    >
-                        To publish now run the following command in your terminal:
-                        <CodeBlock
-                            language={'bash'}
-                            copyable={true}
-                            code={[`cd ${planner.asset!.path}`, `kap registry publish`].join('\n')}
-                        />
-                    </Typography>
-                </Box>
+                    <Typography variant="body2">To publish now run the following command in your terminal:</Typography>
+                    <CodeBlock
+                        language={'bash'}
+                        copyable={true}
+                        code={[`cd ${planner.asset!.path}`, `kap registry publish`].join('\n')}
+                    />
+                </Stack>
             </Popover>
 
             {showPlanTakesTimeTip && (

--- a/src/renderer/components/plan-overview/PlanOverview.tsx
+++ b/src/renderer/components/plan-overview/PlanOverview.tsx
@@ -73,15 +73,15 @@ export const PlanOverview = (props: Props) => {
                 bgcolor: 'white',
                 pl: 2,
                 pr: 2,
+                pt: '50px',
             }}
         >
-            <Box sx={{ pt: '50px' }}></Box>
             <Stack
-                direction={'column'}
                 sx={{
                     margin: '0 auto',
                     maxWidth: '1152px',
                 }}
+                gap={4}
             >
                 <GetStartedHeader
                     assetImporter={assetImporter}

--- a/src/renderer/components/plan-overview/components/GetStartedHeader.tsx
+++ b/src/renderer/components/plan-overview/components/GetStartedHeader.tsx
@@ -89,14 +89,8 @@ export const GetStartedHeader = (props: Props) => {
     const kapetaContext = useKapetaContext();
 
     return (
-        <Stack
-            direction={'column'}
-            sx={{
-                pt: 2,
-                pb: 2,
-            }}
-        >
-            <Typography variant={'h6'} pb={2} pt={2}>
+        <Stack>
+            <Typography variant={'h6'} pb={2}>
                 Get started
             </Typography>
             <Stack

--- a/src/renderer/components/plan-overview/components/SamplePlanSection.tsx
+++ b/src/renderer/components/plan-overview/components/SamplePlanSection.tsx
@@ -19,7 +19,7 @@ interface Props {
 export const SamplePlanSection = (props: Props) => {
     return (
         <Box className={'sample-plan-section'}>
-            <Typography variant={'h6'} pb={2} pt={2}>
+            <Typography variant={'h6'} pb={2}>
                 Sample Plan
             </Typography>
             <Stack direction={'row'} gap={3}>

--- a/src/renderer/components/plan-overview/components/YourPlansList.tsx
+++ b/src/renderer/components/plan-overview/components/YourPlansList.tsx
@@ -183,7 +183,7 @@ export const YourPlansList = (props: Props) => {
     });
     return (
         <Box className={className}>
-            <Typography variant={'h6'} pb={2} pt={2}>
+            <Typography variant={'h6'} pb={2}>
                 Your plans
             </Typography>
             <YourPlansListInner {...props} />

--- a/src/renderer/components/shell/MainLayout.tsx
+++ b/src/renderer/components/shell/MainLayout.tsx
@@ -96,7 +96,7 @@ export const MainLayout = (props: Props) => {
                                 );
                             })}
 
-                        <Divider />
+                        <Divider sx={{ my: 1 }} />
                         <SidebarListItem>
                             <SidebarListItemButton
                                 onClick={() => kapetaContext.blockHub.open()}
@@ -114,7 +114,19 @@ export const MainLayout = (props: Props) => {
                             mt: 'auto',
                             height: '96px',
                             ml: drawerIsOpen ? '0px' : '6px',
-                            transition: 'margin-left 225ms cubic-bezier(0.4, 0, 0.6, 1)',
+                            transition: (theme) =>
+                                theme.transitions.create(
+                                    'margin-left',
+                                    drawerIsOpen
+                                        ? {
+                                              easing: theme.transitions.easing.sharp,
+                                              duration: theme.transitions.duration.enteringScreen,
+                                          }
+                                        : {
+                                              easing: theme.transitions.easing.sharp,
+                                              duration: theme.transitions.duration.leavingScreen,
+                                          }
+                                ),
                         }}
                     >
                         <Box

--- a/src/renderer/components/shell/components/ContextPicker.tsx
+++ b/src/renderer/components/shell/components/ContextPicker.tsx
@@ -57,7 +57,6 @@ export const ContextPicker = (props: ContextPickerProps) => {
         <>
             <SidebarList
                 sx={{
-                    pt: 0,
                     '& .MuiAvatar-root': {
                         width: 24,
                         height: 24,

--- a/src/renderer/components/shell/components/MiniDrawer.tsx
+++ b/src/renderer/components/shell/components/MiniDrawer.tsx
@@ -18,7 +18,7 @@ const openedMixin = (theme: Theme): CSSObject => ({
     }),
     overflowX: 'hidden',
     padding: theme.spacing(2),
-    paddingTop: '48px',
+    paddingTop: theme.spacing(6),
 });
 
 const closedMixin = (theme: Theme): CSSObject => ({
@@ -33,7 +33,7 @@ const closedMixin = (theme: Theme): CSSObject => ({
         width: `calc(${theme.spacing(8)} + 1px)`,
     },
     padding: theme.spacing(1),
-    paddingTop: '48px',
+    paddingTop: theme.spacing(5),
 });
 
 /**

--- a/src/renderer/components/shell/components/SidebarMenu.tsx
+++ b/src/renderer/components/shell/components/SidebarMenu.tsx
@@ -12,7 +12,6 @@ interface SidebarProps {
 export const SidebarList = styled(List, {
     shouldForwardProp: (prop) => prop !== 'isOpen',
 })<SidebarProps>(({ theme, isOpen }) => ({
-    padding: theme.spacing(1),
     '& .MuiListItemIcon-root': {
         // alignContent: "center",
         color: theme.palette.text.primary,
@@ -21,7 +20,6 @@ export const SidebarList = styled(List, {
         minWidth: '40px',
         paddingRight: theme.spacing(1.5),
     },
-    gap: '24px',
     '& .MuiListItemButton-root': {
         padding: theme.spacing(1, isOpen ? 2 : 0.5),
     },
@@ -30,6 +28,14 @@ export const SidebarList = styled(List, {
 export const SidebarListItem = styled(ListItem)(({ theme }) => ({
     padding: 0,
     borderRadius: '6px',
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+    '&:first-child': {
+        marginTop: 0,
+    },
+    '&:last-child': {
+        marginBottom: 0,
+    },
 }));
 
 export const SidebarListItemButton = styled(ListItemButton)<{ href?: string }>({


### PR DESCRIPTION
- Fix left menu styling
- Fix space between "Get started", "Sample plan" and "Your plans"
- Fix spacing between elements in "Publish popover"
- Fix scrollbar in codeblock in "Publish popover"

https://github.com/kapetacom/app-desktop-builder/assets/1045799/f5c6bfaf-b59d-4211-8fec-73a002d2d986

