### PR TITLE
Set up prerelease workflow [KAP-2014]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - production
 
 jobs:
   semantic-release:

--- a/package.json
+++ b/package.json
@@ -335,6 +335,14 @@
                     "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
                 }
             ]
+        ],
+        "branches": [
+            "production",
+            {
+                "name": "master",
+                "prerelease": true,
+                "channel": "beta"
+            }
         ]
     },
     "devEngines": {


### PR DESCRIPTION
Change our default publishing workflow to create beta releases from master, and "production" (latest channel) releases on `production` branch. To create a new non-beta release we merge from `master` to `production`.

Needs testing wrt the picking up `latest` channel changes, but I believe `semantic-release` will be intelligent about it for us.

[Semantic-release docs](https://semantic-release.gitbook.io/semantic-release/usage/configuration#branches)