### PR TITLE
Make links open in external browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3693,9 +3693,9 @@
             "integrity": "sha512-mafdrXCc2mtq5oY2sIj+bAJf1epGrh2mz3mwFf2u+Gii/2Mh/urjtpgXv99simQHVk6xNPb/s49GvvxTvE3erQ=="
         },
         "node_modules/@kapeta/ui-web-components": {
-            "version": "0.57.0",
-            "resolved": "https://registry.npmjs.org/@kapeta/ui-web-components/-/ui-web-components-0.57.0.tgz",
-            "integrity": "sha512-H9Azcrcb5R2FiynPxEEL2xDN97ifkjt8VwWVYeu1iv/qgTZw3sQdXMjF7HkNC9OwUVkA6VmEU23P7MJ9PeVpjA==",
+            "version": "0.57.1",
+            "resolved": "https://registry.npmjs.org/@kapeta/ui-web-components/-/ui-web-components-0.57.1.tgz",
+            "integrity": "sha512-tQ+XUEZFaHm9mDXN2Sx057ghMk9qJB9XJWup/ia5CArXvOEq2KlmQuYBYYVSTubt4xPBP5eRRjBsHMewhBUjdg==",
             "dependencies": {
                 "@kapeta/nodejs-utils": "<2",
                 "@kapeta/style": "^0.94.0",


### PR DESCRIPTION
Setting `target="_blank"` in links generated by `<Markdown>` ([merged PR](https://github.com/kapetacom/ui-web-components/pull/175)) makes the link open in external browser:




https://github.com/kapetacom/app-desktop-builder/assets/1045799/38990eb8-7825-437c-9f1d-595cd36b2c05

