### PR TITLE
Set buildVersion to empty string

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
     },
     "build": {
         "productName": "Kapeta",
+        "buildVersion": "",
         "appId": "com.kapeta.Kapeta",
         "asar": true,
         "asarUnpack": "**\\*.{node,dll}",


### PR DESCRIPTION
This avoids the version showing up as buildNumber in the about dialog

<img width="396" alt="image" src="https://github.com/kapetacom/app-desktop-builder/assets/1045799/3a432aad-6fe4-49fc-b5cf-00b9077317c6">
