### PR TITLE
Bump electron-ide-opener + Make splash draggable

### DIFF
--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -10,7 +10,7 @@
             "hasInstallScript": true,
             "license": "BUSL-1.1",
             "dependencies": {
-                "@kapeta/electron-ide-opener": "^1.0.5",
+                "@kapeta/electron-ide-opener": "^1.1.0",
                 "@kapeta/local-cluster-config": "<2",
                 "@kapeta/local-cluster-service": ">=0.27.0 <2",
                 "@kapeta/nodejs-process": "^1.2.0"
@@ -1222,9 +1222,9 @@
             }
         },
         "node_modules/@kapeta/electron-ide-opener": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@kapeta/electron-ide-opener/-/electron-ide-opener-1.0.5.tgz",
-            "integrity": "sha512-aAHfAY0QmT0d6HDLN7iSMXxmVAdHAxTEcmicc6Lcelr23IslyNE60DWcEXiWeTSYMJAaOK1IK3lXRJR8ldJw0w==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@kapeta/electron-ide-opener/-/electron-ide-opener-1.1.0.tgz",
+            "integrity": "sha512-k6kjYfD5TqNcdeHydFB96GoEOnkfnJ7EOB6NhWhZ8P5ZZX6xYc5HzRKlocqAIaSHEukjaQJBeONODlZQKDldJw==",
             "dependencies": {
                 "app-path": "^3.3.0",
                 "registry-js": "^1.15.1"

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -19,7 +19,7 @@
         "link-modules": "node -r ts-node/register ../../.erb/scripts/link-modules.ts"
     },
     "dependencies": {
-        "@kapeta/electron-ide-opener": "^1.0.5",
+        "@kapeta/electron-ide-opener": "^1.1.0",
         "@kapeta/local-cluster-config": "<2",
         "@kapeta/local-cluster-service": ">=0.27.0 <2",
         "@kapeta/nodejs-process": "^1.2.0"

--- a/src/renderer/modals/splash/SplashContent.tsx
+++ b/src/renderer/modals/splash/SplashContent.tsx
@@ -157,6 +157,7 @@ export const SplashContent = (props: Props) => {
     return (
         <Paper
             elevation={elevation}
+            className="allow-drag-app"
             sx={{
                 position: 'relative',
                 overflow: 'hidden',
@@ -307,7 +308,7 @@ export const SplashContent = (props: Props) => {
             </div>
             <div className="right">
                 {hasError && (
-                    <div className={'errors'}>
+                    <div className={'errors disallow-drag-app'}>
                         <Typography
                             variant={'body2'}
                             sx={{


### PR DESCRIPTION
- Bump `@kapeta/electron-ide-opener `
- Make splash screen draggable


https://github.com/kapetacom/app-desktop-builder/assets/1045799/2e539530-f135-4b11-addf-dabc229ff08d

