### PR TITLE
fix: Set build version to short commit hash

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
           npm install
           npm run postinstall
           npm run build
+          npm run set-build-version
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'
       - name: Create sentry release
@@ -54,6 +55,7 @@ jobs:
           npm install
           npm run postinstall
           npm run build
+          npm run set-build-version
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'
 
@@ -82,6 +84,7 @@ jobs:
           npm install
           npm run postinstall
           npm run build
+          npm run set-build-version
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'
 
@@ -159,6 +162,7 @@ jobs:
           npm install
           npm run postinstall
           npm run build
+          npm run set-build-version
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "build": "concurrently \"npm run build:main\" \"npm run build:renderer\"",
         "build:main": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.main.prod.ts && cp -rf src/service release/app/dist/service",
         "build:renderer": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.prod.ts",
+        "set-build-version": "jq '.build.buildVersion = \"'$(git rev-parse --short HEAD)'\"' package.json > tmp.json && mv tmp.json package.json && prettier --write package.json",
         "postinstall": "ts-node .erb/scripts/check-native-dep.js && electron-builder install-app-deps && npm run dev:dll",
         "lint:eslint": "cross-env NODE_ENV=development eslint . --ext .js,.jsx,.ts,.tsx",
         "lint:tsc": "tsc --noEmit",
@@ -210,7 +211,7 @@
     },
     "build": {
         "productName": "Kapeta",
-        "buildVersion": "",
+        "buildVersion": "local",
         "appId": "com.kapeta.Kapeta",
         "asar": true,
         "asarUnpack": "**\\*.{node,dll}",


### PR DESCRIPTION
I would look like this on mac, and hopefully not break Linux and Windows builds 🤞 


<img width="396" alt="Screenshot 2023-11-28 at 11 41 16" src="https://github.com/kapetacom/app-desktop-builder/assets/1045799/ef51c176-d8e2-4209-8805-9930a0737685">
