### PR TITLE
fix: Move set-build-version to node

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "build": "concurrently \"npm run build:main\" \"npm run build:renderer\"",
         "build:main": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.main.prod.ts && cp -rf src/service release/app/dist/service",
         "build:renderer": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.prod.ts",
-        "set-build-version": "jq '.build.buildVersion = \"'$(git rev-parse --short HEAD)'\"' package.json > tmp.json && mv tmp.json package.json && prettier --write package.json",
+        "set-build-version": "node set-build-version.js && prettier --write package.json",
         "postinstall": "ts-node .erb/scripts/check-native-dep.js && electron-builder install-app-deps && npm run dev:dll",
         "lint:eslint": "cross-env NODE_ENV=development eslint . --ext .js,.jsx,.ts,.tsx",
         "lint:tsc": "tsc --noEmit",

--- a/set-build-version.js
+++ b/set-build-version.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+const packageJsonPath = path.join(__dirname, 'package.json');
+const packageJson = require(packageJsonPath);
+
+const execSync = require('child_process').execSync;
+const commitHash = execSync('git rev-parse --short HEAD').toString().trim();
+
+packageJson.build = packageJson.build || {};
+packageJson.build.buildVersion = commitHash;
+
+fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 4), 'utf8');


### PR DESCRIPTION
The approach with `jq` failed on windows due to the different ways in which Windows and Unix-like systems handle command line quoting and string interpolation. To avoid such shell-specific quoting issues I have moved to node instead.