### PR TITLE
Do not send messages to a destroyed window (KAP-2121) + remove eslint from lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
         "recalculate-hash": "node src/scripts/recalculate-hash.js"
     },
     "lint-staged": {
-        "*.{js,jsx,ts,tsx}": [
-            "cross-env NODE_ENV=development eslint --cache"
-        ],
         "*.json,.{eslintrc,prettierrc}": [
             "prettier --ignore-path .eslintignore --parser json --write"
         ],

--- a/src/main/main/AutoUpdateHelper.ts
+++ b/src/main/main/AutoUpdateHelper.ts
@@ -34,7 +34,7 @@ export class AutoUpdateHelper {
         initiatedByUser: boolean,
         data?: any
     ) {
-        if (!main) {
+        if (!main || main.isDestroyed()) {
             return;
         }
 


### PR DESCRIPTION
Changes:

- Do not send messages to a destroyed window
- No need to run eslint as part of lint-staged as long as the eslint setup is broken