### PR TITLE
fix: Gracefully handle errors in plan YML

### DIFF
--- a/src/renderer/components/general/ExceptionWrapper.tsx
+++ b/src/renderer/components/general/ExceptionWrapper.tsx
@@ -1,0 +1,82 @@
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
+import { Alert, AlertProps, AlertTitle, Box, BoxProps, Typography } from '@mui/material';
+import React, { PropsWithChildren } from 'react';
+import { AssetInfo } from '@kapeta/ui-web-plan-editor';
+import { Plan, validateSchema } from '@kapeta/schemas';
+import { getAssetTitle } from '../plan-editor/helpers';
+import { CoreTypes } from '@kapeta/ui-web-components';
+
+interface SharedProps {
+    sx?: AlertProps['sx'];
+    title?: string;
+    resolution?: React.ReactNode;
+}
+
+export const ErrorBox = (props: { error: React.ReactNode } & SharedProps) => {
+    return (
+        <Alert variant={'filled'} severity={'warning'} sx={props.sx}>
+            <AlertTitle>{props.title ?? 'Something went wrong'}</AlertTitle>
+            {props.error}
+            {props.resolution}
+        </Alert>
+    );
+};
+
+export const ExceptionWrapper = (props: PropsWithChildren & SharedProps) => {
+    return (
+        <ErrorBoundary
+            fallbackRender={(fallback) => (
+                <ErrorBox
+                    error={
+                        <>
+                            <Typography>Got the following error:</Typography>
+                            <Typography fontWeight={'bold'}>{fallback.error.message}</Typography>
+                        </>
+                    }
+                    {...props}
+                />
+            )}
+        >
+            {props.children}
+        </ErrorBoundary>
+    );
+};
+
+export const PlanExceptionWrapper = (props: PropsWithChildren & { plan?: AssetInfo<Plan>; sx?: AlertProps['sx'] }) => {
+    if (!props.plan) {
+        return <>{props.children}</>;
+    }
+    const planName = getAssetTitle(props.plan);
+
+    const schemaErrors = validateSchema(CoreTypes.PLAN, props.plan.content);
+
+    const errorTitle = `Failed to load plan "${planName}"`;
+    const resolutionUi = (
+        <Box sx={{ mt: 2 }}>
+            <Typography>Please ensure the plan in the following path exists and is valid:</Typography>
+            <Typography fontWeight={'bold'}>{props.plan.ymlPath ?? 'Unknown path'}</Typography>
+        </Box>
+    );
+
+    if (schemaErrors.length > 0) {
+        return (
+            <ErrorBox
+                sx={props.sx}
+                resolution={resolutionUi}
+                error={
+                    <Box sx={{ mt: 2 }}>
+                        <Typography>Schema validation failed:</Typography>
+                        {schemaErrors.map((error, index) => (
+                            <Typography key={index} fontWeight={'bold'}>
+                                {error.message} in {error.instancePath}
+                            </Typography>
+                        ))}
+                    </Box>
+                }
+                title={errorTitle}
+            />
+        );
+    }
+
+    return <ExceptionWrapper {...props} resolution={resolutionUi} />;
+};

--- a/src/renderer/components/general/ExceptionWrapper.tsx
+++ b/src/renderer/components/general/ExceptionWrapper.tsx
@@ -1,3 +1,7 @@
+/**
+ * Copyright 2023 Kapeta Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 import { Alert, AlertProps, AlertTitle, Box, BoxProps, Typography } from '@mui/material';
 import React, { PropsWithChildren } from 'react';

--- a/src/renderer/components/plan-overview/components/YourPlansList.tsx
+++ b/src/renderer/components/plan-overview/components/YourPlansList.tsx
@@ -5,15 +5,17 @@
 
 import React from 'react';
 import { Box, Button, Slide, Stack, Typography } from '@mui/material';
-import { Plan } from '@kapeta/schemas';
+import { Plan, validateSchema } from '@kapeta/schemas';
 import { toClass } from '@kapeta/ui-web-utils';
 
 import { useKapetaContext } from '../../../hooks/contextHook';
 import { AssetInfo, AssetThumbnail, MissingReference } from '@kapeta/ui-web-plan-editor';
 import { useLoadedPlanContext } from '../../../utils/planContextLoader';
 import { useInstallerService } from '../../../api/installerService';
-import { EmptyStateBox, InstallerService } from '@kapeta/ui-web-components';
+import { CoreTypes, EmptyStateBox, InstallerService } from '@kapeta/ui-web-components';
 import { DesktopReferenceResolutionHandler } from '../../general/DesktopReferenceResolutionHandler';
+import { ErrorBox, ExceptionWrapper, PlanExceptionWrapper } from '../../general/ExceptionWrapper';
+import { getAssetTitle } from '../../plan-editor/helpers';
 
 interface Props {
     plans: AssetInfo<Plan>[];
@@ -142,36 +144,46 @@ const PlanTile = ({
 
     return (
         <Box>
-            <DesktopReferenceResolutionHandler
-                open={resolverOpen}
-                plan={plan.content}
-                planRef={plan.ref}
-                blockAssets={planContext.blocks}
-                missingReferences={missingReferences}
-                onClose={() => setResolverOpen(false)}
-            />
-            <AssetThumbnail
-                width={366}
-                height={262}
-                asset={plan}
-                onMissingReferences={(missingReferences) => {
-                    if (resolverOpen && missingReferences.length < 1) {
-                        setResolverOpen(false);
-                    }
-                    setMissingReferences(missingReferences);
+            <PlanExceptionWrapper
+                plan={plan}
+                sx={{
+                    width: '368px',
+                    height: '264px',
+                    boxSizing: 'border-box',
+                    borderRadius: '10px',
                 }}
-                installerService={installerService}
-                onClick={() => {
-                    if (missingReferences.length > 0) {
-                        setResolverOpen(true);
-                    } else {
-                        onPlanOpen && onPlanOpen(plan);
-                    }
-                }}
-                loadPlanContext={() => {
-                    return planContext;
-                }}
-            />
+            >
+                <DesktopReferenceResolutionHandler
+                    open={resolverOpen}
+                    plan={plan.content}
+                    planRef={plan.ref}
+                    blockAssets={planContext.blocks}
+                    missingReferences={missingReferences}
+                    onClose={() => setResolverOpen(false)}
+                />
+                <AssetThumbnail
+                    width={366}
+                    height={262}
+                    asset={plan}
+                    onMissingReferences={(missingReferences) => {
+                        if (resolverOpen && missingReferences.length < 1) {
+                            setResolverOpen(false);
+                        }
+                        setMissingReferences(missingReferences);
+                    }}
+                    installerService={installerService}
+                    onClick={() => {
+                        if (missingReferences.length > 0) {
+                            setResolverOpen(true);
+                        } else {
+                            onPlanOpen && onPlanOpen(plan);
+                        }
+                    }}
+                    loadPlanContext={() => {
+                        return planContext;
+                    }}
+                />
+            </PlanExceptionWrapper>
         </Box>
     );
 };

--- a/src/renderer/utils/planContextLoader.ts
+++ b/src/renderer/utils/planContextLoader.ts
@@ -109,16 +109,26 @@ export const useLoadedPlanContext = (plan: Plan | undefined) => {
     const [loading, setLoading] = useState(true);
 
     const dependencyHash = useMemo(() => {
-        if (!plan) {
+        try {
+            if (!plan) {
+                return '';
+            }
+            const deps = plan.spec?.blocks?.map((block) => block.block.ref) ?? [];
+            return `${plan.metadata.name}:${deps.join(',')}`;
+        } catch (e) {
+            console.warn('Failed to compute dependency hash', e);
             return '';
         }
-        const deps = plan.spec?.blocks?.map((block) => block.block.ref) ?? [];
-        return `${plan.metadata.name}:${deps.join(',')}`;
     }, [plan]);
 
     const localAssetsResult = useLocalAssets();
     const localBlocks = useMemo(() => {
-        return !localAssetsResult.loading && localAssetsResult.data ? toBlocks(localAssetsResult.data) : undefined;
+        try {
+            return !localAssetsResult.loading && localAssetsResult.data ? toBlocks(localAssetsResult.data) : undefined;
+        } catch (e) {
+            console.warn('Failed to compute local blocks', e);
+            return [];
+        }
     }, [localAssetsResult.loading, localAssetsResult.data]);
 
     const missingData = !plan || !localAssetsResult.data || !localBlocks;


### PR DESCRIPTION
<img width="1284" alt="image" src="https://github.com/kapetacom/app-desktop-builder/assets/441655/3b667858-2983-4ec2-99ea-ee7a449fdd35">
<img width="1587" alt="image" src="https://github.com/kapetacom/app-desktop-builder/assets/441655/25e9912e-7c93-4896-a8c8-5450c6b8b6db">
