### PR TITLE
fix: Set z-index for notification popper

### DIFF
--- a/src/renderer/components/shell/NotificationsDropdown.tsx
+++ b/src/renderer/components/shell/NotificationsDropdown.tsx
@@ -171,6 +171,9 @@ export const NotificationsDropdown = withTheme((props: NotificationsDropdownProp
                 },
             ]}
             transition
+            style={{
+                zIndex: 1500,
+            }}
         >
             {({ TransitionProps }) => (
                 <Grow


### PR DESCRIPTION
![image](https://github.com/kapetacom/app-desktop-builder/assets/1045799/5ae9a3cc-4122-49a3-8768-ded4d36c3f13)
