### PR TITLE
fix: Do not notify sentry about intercom errors

### DIFF
--- a/src/main/sentry.ts
+++ b/src/main/sentry.ts
@@ -10,4 +10,12 @@ Sentry.init({
     dsn: 'https://90b96576054385630d501d86133d372c@o4505820837249024.ingest.sentry.io/4505820839018496',
     enabled: process.env.NODE_ENV === 'production',
     release: `v${packageJson.version}`,
+    beforeSend(event) {
+        // If intercom was involved, don't send the event as it's not actionable
+        if (event.exception?.values?.[0]?.stacktrace?.frames?.some((frame) => frame.abs_path?.match(/intercom/i))) {
+            return null;
+        }
+
+        return event;
+    },
 });


### PR DESCRIPTION
This https://kapeta.sentry.io/issues/4774615355/?project=4505827896328192 was caused by intercom

We want to ignore errors in 3rd party scripts as those are not actionable