### PR TITLE
fix: confirm when dimissing "dirty" panels

### DIFF
--- a/src/renderer/components/plan-editor/panels/editor/EditorPanels.tsx
+++ b/src/renderer/components/plan-editor/panels/editor/EditorPanels.tsx
@@ -51,6 +51,7 @@ import { useNamespacesForField } from '../../../../hooks/useNamespacesForField';
 import { fromTypeProviderToAssetType } from '../../../../utils/assetTypeConverters';
 import { updateBlockFromMapping } from '../../helpers';
 import { InstanceEditor } from './inner/InstanceEditor';
+import { useEffect } from 'react';
 
 function getResourceVersions(dataKindUri: KapetaURI) {
     const allVersions = ResourceTypeProvider.getVersionsFor(dataKindUri.fullName);
@@ -322,12 +323,24 @@ export const EditorPanels: React.FC<Props> = (props) => {
                 return cloneDeep(props.info.item.resource);
         }
 
-        return {};
+        return {} as any;
     }, [props.info]);
 
+    useEffect(() => {
+        setCurrentData(initialValue);
+    }, [initialValue]);
+
     const onPanelCancel = async () => {
+        const hasEditorChanges =
+            // Entity editor
+            !_.isEqual(currentData?.spec?.entities?.source, initialValue?.spec?.entities?.source) ||
+            // REST editor
+            !_.isEqual(currentData?.spec?.source, initialValue?.spec?.source) ||
+            // Parameters editor
+            !_.isEqual(currentData?.spec?.configuration, initialValue?.spec?.configuration);
+
         if (
-            !_.isEqual(currentData, initialValue) &&
+            hasEditorChanges &&
             !(await confirm({
                 title: 'Unsaved changes',
                 content: 'Are you sure you want to close this panel without saving?',


### PR DESCRIPTION
This is probably an over correction, since this will apply to all panels that have data differing from "initialValue".
**Now applies for DSL / REST / Configuration editors**


<img width="1142" alt="Screenshot 2024-01-08 at 21 49 42" src="https://github.com/kapetacom/app-desktop-builder/assets/296057/d66b3fdf-2d27-4b77-afde-07a3b7c943b8">
